### PR TITLE
Run freshclam once only with DNS to help minimise 429 errors

### DIFF
--- a/hmpps-clamav/Dockerfile
+++ b/hmpps-clamav/Dockerfile
@@ -6,7 +6,7 @@ COPY --chown=clamav:clamav ./*.conf /etc/clamav
 COPY --chown=clamav:clamav eicar.com /
 COPY --chown=clamav:clamav ./readyness.sh /
 
-RUN freshclam --no-dns && freshclam
+RUN freshclam
 
 VOLUME /var/lib/clamav
 

--- a/hmpps-clamav/Dockerfile.freshclammed
+++ b/hmpps-clamav/Dockerfile.freshclammed
@@ -1,7 +1,6 @@
 FROM ghcr.io/ministryofjustice/hmpps-clamav:latest
 
-RUN freshclam --no-dns && \
-    freshclam
+RUN freshclam
 
 EXPOSE 3310
 


### PR DESCRIPTION
Running freshclam with --no-dns is more likely to result in a 429 http error (too many requests)