### PR TITLE
Refactor to add user to clamav dockerfile

### DIFF
--- a/hmpps-clamav/Dockerfile
+++ b/hmpps-clamav/Dockerfile
@@ -3,6 +3,13 @@ FROM clamav/clamav:stable_base
 COPY kubernetes.repo /etc/yum.repos.d/kubernetes.repo
 
 COPY --chown=clamav:clamav ./*.conf /etc/clamav
+
+RUN groupadd --gid 1000 clamav && \
+    useradd -r -g clamav -u 1000 clamav -d /var/lib/clamav && \
+    mkdir -p /var/lib/clamav && \
+    mkdir /usr/local/share/clamav && \
+    chown -R clamav:clamav /var/lib/clamav /usr/local/share/clamav
+
 COPY --chown=clamav:clamav eicar.com /
 COPY --chown=clamav:clamav ./readyness.sh /
 

--- a/hmpps-clamav/Dockerfile
+++ b/hmpps-clamav/Dockerfile
@@ -3,15 +3,15 @@ FROM clamav/clamav:stable_base
 COPY kubernetes.repo /etc/yum.repos.d/kubernetes.repo
 
 COPY --chown=clamav:clamav ./*.conf /etc/clamav
-
-RUN groupadd --gid 1000 clamav && \
-    useradd -r -g clamav -u 1000 clamav -d /var/lib/clamav && \
-    mkdir -p /var/lib/clamav && \
-    mkdir /usr/local/share/clamav && \
-    chown -R clamav:clamav /var/lib/clamav /usr/local/share/clamav
-
 COPY --chown=clamav:clamav eicar.com /
 COPY --chown=clamav:clamav ./readyness.sh /
+
+# permissions
+RUN mkdir /var/run/clamav && \
+    chown clamav:clamav /var/run/clamav && \
+    chmod 750 /var/run/clamav
+
+USER 100
 
 RUN freshclam
 


### PR DESCRIPTION
We added a bug when moving to the Clamav docker image. 

Clamav will now attempt to run as root on MoJ Cloud Platform which is not permitted. 

Adding in a user with the correct permissions should fix this issue