### PR TITLE
HEAT-2: update Helm version to fix security alerts; clear trivy ignore as no longer required

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,0 @@
-# Waiting on https://github.com/helm/helm/issues/10314
-CVE-2021-41092

--- a/hmpps-devops-tools/Dockerfile
+++ b/hmpps-devops-tools/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-slim-bullseye
 
 ENV \
-  HELM_VERSION=3.8.0 \
+  HELM_VERSION=3.9.0 \
   KUBECTL_VERSION=1.20.15
 
 RUN apt-get clean && apt-get update && apt-get upgrade -y \


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/HEAT-2