### PR TITLE
HEAT-11: ignore CVE-2022-1996

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# Waiting on https://github.com/helm/helm/issues/11081
+CVE-2022-1996


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/HEAT-11

waiting on https://github.com/helm/helm/issues/11081 which should be fixed in helm `3.9.3`