### PR TITLE
Adding a mysql tools Docker image.

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -13,6 +13,7 @@ jobs:
         dockerfile-dir:
           - hmpps-devops-tools
           - hmpps-mssql-tools
+          - hmpps-mysql-tools
           - hmpps-clamav
     permissions:
       packages: write

--- a/.github/workflows/trivy_scan_latest.yml
+++ b/.github/workflows/trivy_scan_latest.yml
@@ -15,6 +15,7 @@ jobs:
         dockerfile-dir:
           - hmpps-devops-tools
           - hmpps-mssql-tools
+          - hmpps-mysql-tools
           - hmpps-clamav
     permissions:
       packages: write

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ These images are built in github actions see `.github/workflows/docker-build-pus
 | --- | --- | --- |
 | `hmpps-devops-tools` | contains various useful tools (az cli, aws cli, kubectl, helm), runs as non-root | <https://github.com/ministryofjustice/hmpps-tools-images/pkgs/container/hmpps-devops-tools> |
 | `hmpps-mssql-tools` | contains mssql-tools and az cli. For sqlserver db refresh jobs | <https://github.com/ministryofjustice/hmpps-tools-images/pkgs/container/hmpps-mssql-tools> |
+| `hmpps-mysql-tools`         | contains mysql-client and aws cli. For mysql db refresh jobs                     | <https://github.com/ministryofjustice/hmpps-tools-images/pkgs/container/hmpps-mysql-tools>         |
 | `hmpps-clamav` | ClamAV base image, see README in folder | <https://github.com/ministryofjustice/hmpps-tools-images/pkgs/container/hmpps-clamav> |
 | `hmpps-clamav-freshclammed` | ClamAV image, twice daily updated virus DB, see README in folder | <https://github.com/ministryofjustice/hmpps-tools-images/pkgs/container/hmpps-clamav-freshclammed> |
 

--- a/hmpps-mysql-tools/Dockerfile
+++ b/hmpps-mysql-tools/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.16.2
+
+RUN apk update && \
+  apk upgrade && \
+  apk add --no-cache aws-cli mysql-client bash


### PR DESCRIPTION
This PR adds a Docker image for running mysql commands with the aws cli.

It's intended to be re-usable for other projects using mysql or mariadb.  But it's original purpose is for the prisoner content hub, as we want to start backing up out databases to s3, and using this to re-import into dev and staging.