### PR TITLE
Bump GitHub Actions versions

### DIFF
--- a/.github/workflows/clamav-daily.yml
+++ b/.github/workflows/clamav-daily.yml
@@ -19,11 +19,11 @@ jobs:
       security-events: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.dockerfile-dir }}-freshclammed
           flavor: |
@@ -35,14 +35,14 @@ jobs:
             type=ref,event=pr
             type=sha
       - name: Log in to GitHub container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build container image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: ./${{ matrix.dockerfile-dir }}/Dockerfile.freshclammed
           context: ./${{ matrix.dockerfile-dir }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Push container image to repository
         if: ${{ success() && github.ref == 'refs/heads/main' }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: ./${{ matrix.dockerfile-dir }}/Dockerfile.freshclammed
           context: ./${{ matrix.dockerfile-dir }}
@@ -75,7 +75,7 @@ jobs:
       - name: Slack notification
         id: slack
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.14.0
+        uses: slackapi/slack-github-action@v1.21.0
         with:
           channel-id: ${{ secrets.SLACK_GITHUB_ALERTS }}
           slack-message: "_Job:_ ${{ github.job }}\n_Status:_ ${{ job.status }}\n_Workflow:_ ${{ github.workflow }}\n_Repo:_ ${{ github.repository }}\n<https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View on github>\n"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -24,11 +24,11 @@ jobs:
       security-events: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.dockerfile-dir }}
           flavor: |
@@ -40,14 +40,14 @@ jobs:
             type=ref,event=pr
             type=sha
       - name: Log in to GitHub container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build container image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./${{ matrix.dockerfile-dir }}
           pull: true
@@ -58,7 +58,7 @@ jobs:
       - name: Push container image to repository
         # Only push to repo if on main branch
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./${{ matrix.dockerfile-dir }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -68,7 +68,7 @@ jobs:
       - name: Slack notification
         id: slack
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.14.0
+        uses: slackapi/slack-github-action@v1.21.0
         with:
           channel-id: ${{ secrets.SLACK_GITHUB_ALERTS }}
           slack-message: "_Job:_ ${{ github.job }}\n_Status:_ ${{ job.status }}\n_Workflow:_ ${{ github.workflow }}\n_Repo:_ ${{ github.repository }}\n<https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View on github>\n"

--- a/.github/workflows/trivy_scan_latest.yml
+++ b/.github/workflows/trivy_scan_latest.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # Need to checkout the repo to get the .trivyignore file
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
@@ -40,7 +40,7 @@ jobs:
       - name: Slack notification
         id: slack
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.14.0
+        uses: slackapi/slack-github-action@v1.21.0
         with:
           channel-id: 'hmpps_tech_alerts_security'
           slack-message: "_Job:_ ${{ github.job }}\n_Status:_ ${{ job.status }}\n_Workflow:_ ${{ github.workflow }}\n_Repo:_ ${{ github.repository }}\n<https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View on github>\n"


### PR DESCRIPTION
I raised https://github.com/ministryofjustice/hmpps-utility-container-images/pull/40 and saw in the [GitHub Actions summary](https://github.com/ministryofjustice/hmpps-utility-container-images/actions/runs/3263360257)

> [Build-Scan-Push (hmpps-mssql-tools)](https://github.com/ministryofjustice/hmpps-utility-container-images/actions/runs/3263360257/jobs/5362342666)
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, docker/metadata-action, docker/login-action, docker/build-push-action, docker/build-push-action, docker/login-action, actions/checkout

Which won't be flagged after bumping the versions