### PR TITLE
Update slack-github-action

### DIFF
--- a/.github/workflows/clamav-daily.yml
+++ b/.github/workflows/clamav-daily.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Slack notification
         id: slack
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.21.0
+        uses: slackapi/slack-github-action@v1.23.0
         with:
           channel-id: ${{ secrets.SLACK_GITHUB_ALERTS }}
           slack-message: "_Job:_ ${{ github.job }}\n_Status:_ ${{ job.status }}\n_Workflow:_ ${{ github.workflow }}\n_Repo:_ ${{ github.repository }}\n<https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View on github>\n"

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Slack notification
         id: slack
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.21.0
+        uses: slackapi/slack-github-action@v1.23.0
         with:
           channel-id: ${{ secrets.SLACK_GITHUB_ALERTS }}
           slack-message: "_Job:_ ${{ github.job }}\n_Status:_ ${{ job.status }}\n_Workflow:_ ${{ github.workflow }}\n_Repo:_ ${{ github.repository }}\n<https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View on github>\n"

--- a/.github/workflows/trivy_scan_latest.yml
+++ b/.github/workflows/trivy_scan_latest.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Slack notification
         id: slack
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.21.0
+        uses: slackapi/slack-github-action@v1.23.0
         with:
           channel-id: 'hmpps_tech_alerts_security'
           slack-message: "_Job:_ ${{ github.job }}\n_Status:_ ${{ job.status }}\n_Workflow:_ ${{ github.workflow }}\n_Repo:_ ${{ github.repository }}\n<https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View on github>\n"


### PR DESCRIPTION
Should fix warnings
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: slackapi/slack-github-action@v1.21.0. For more information see: