### PR TITLE
Grab Postgres v15 client

### DIFF
--- a/hmpps-devops-tools/Dockerfile
+++ b/hmpps-devops-tools/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar x
 
 RUN curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/postgresql.asc.gpg > /dev/null \
     && echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
-    && apt update && apt install  --no-install-recommends -qy postgresql-client-14
+    && apt update && apt install --no-install-recommends -qy postgresql-client-15
 
 RUN addgroup --gid 2000 --system appgroup && \
     adduser --uid 2000 --system appuser --gid 2000


### PR DESCRIPTION
Follow on from https://github.com/ministryofjustice/hmpps-utility-container-images/pull/34 and as per [Postgres mailing list](https://www.postgresql.org/message-id/19abe150-d8fe-5ae7-9b93-d70dfc21dd1c%40aklaver.com)
> FYI, it will work the other way e.g. a newer version of pg_dump can dump an older version of Postgres.