### PR TITLE
Add an image for running Python scripts with dependencies

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -18,6 +18,7 @@ jobs:
           - hmpps-mssql-tools
           - hmpps-mysql-tools
           - hmpps-clamav
+          - hmpps-python-deps
     permissions:
       packages: write
       contents: read

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ These images are built in github actions see `.github/workflows/docker-build-pus
 | `hmpps-mysql-tools` | contains mysql-client and aws cli. For mysql db refresh jobs, runs as non-root | <https://github.com/ministryofjustice/hmpps-tools-images/pkgs/container/hmpps-mysql-tools>         |
 | `hmpps-clamav` | ClamAV base image, see README in folder | <https://github.com/ministryofjustice/hmpps-tools-images/pkgs/container/hmpps-clamav> |
 | `hmpps-clamav-freshclammed` | ClamAV image, twice daily updated virus DB, see README in folder | <https://github.com/ministryofjustice/hmpps-tools-images/pkgs/container/hmpps-clamav-freshclammed> |
+| `hmpps-python-deps` | Python install with dependencies for running python scripts | <https://github.com/ministryofjustice/hmpps-utility-container-images/pkgs/container/hmpps-python-deps> |
 
 ## Trivy Scan
 

--- a/hmpps-python-deps/Dockerfile
+++ b/hmpps-python-deps/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:12-slim AS build
+RUN apt-get update && \
+    apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev && \
+    python3 -m venv /venv && \
+    /venv/bin/pip install --upgrade pip setuptools wheel
+
+FROM build AS build-venv
+COPY requirements.txt .
+RUN /venv/bin/pip install --disable-pip-version-check -r requirements.txt
+
+# Copy the virtualenv into a distroless image
+FROM gcr.io/distroless/python3-debian12
+COPY --from=build-venv /venv /venv
+
+USER nonroot
+
+WORKDIR /app
+ENTRYPOINT ["/venv/bin/python3"]

--- a/hmpps-python-deps/README.md
+++ b/hmpps-python-deps/README.md
@@ -1,0 +1,7 @@
+# hmpps-python-deps
+
+Docker image containing Python dependencies to enable running of Python scripts without needing to install locally. Dependencies included are defined in the [requirements.txt](./requirements.txt) file. Add further dependencies to the [requirements.txt](./requirements.txt) file as needed. To execute a python script with the image dependencies run the image with the local script directory volume mapped:
+
+```sh
+docker run -v .:/app -t -e SOME_ENV_VAR=some-value hmpps-python-deps:latest ./script.py <some-argument>
+```

--- a/hmpps-python-deps/requirements.txt
+++ b/hmpps-python-deps/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pyyaml


### PR DESCRIPTION
Tiny image to make it easier for non-python devs to run scripts that we have in a few other repos