### PR TITLE
Fix kubectl v1.29.9 install

### DIFF
--- a/hmpps-devops-tools/Dockerfile
+++ b/hmpps-devops-tools/Dockerfile
@@ -15,18 +15,21 @@ RUN apt-get clean && apt-get update && apt-get upgrade -y \
 RUN pip install --upgrade pip \
     && pip install --no-cache-dir awscli aws-shell awscli-login boto3 botocore wheel urllib3
 
-RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null \
+RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null \
     && AZ_REPO=$(lsb_release -cs) \
     && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list \
     && apt-get update \
     && apt-get install --no-install-recommends -qy azure-cli
 
-RUN curl -sLo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
-    && chmod +x /usr/local/bin/kubectl
+RUN curl -fsSLO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    curl -fsSLO "https://dl.k8s.io/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" && \
+    echo "$(cat kubectl.sha256)  kubectl" | sha256sum -c && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin/kubectl
 
-RUN curl -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64
+RUN curl -fsSL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /bin/helm && rm -rf linux-amd64
 
-RUN curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/postgresql.asc.gpg > /dev/null \
+RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/postgresql.asc.gpg > /dev/null \
     && echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list \
     && apt update && apt install --no-install-recommends -qy postgresql-client-16
 


### PR DESCRIPTION
Currently, attempting to use kubectl in the latest image version throws an error:
```xml
<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: kubernetes-release/release/v1.29.9/bin/linux/amd64/kubectl</Details></Error>
```

As of 18/09/2024, the Google storage link only has binaries up to v1.28 - see: https://console.cloud.google.com/storage/browser/kubernetes-release/release;tab=objects?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%257B_22k_22_3A_22_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22v1.29_5C_22_22%257D%255D%22))&prefix=v1.29&forceOnObjectsSortingFiltering=false

This PR updates the Dockerfile to use the download links from: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#downloads-for-v1299 and also updates the curl commands to fail if there is an issue downloading the files, to avoid publishing a broken Docker image.