### PR TITLE
Allow hmpps-wiremock to pull WireMock mappings from other repositories

### DIFF
--- a/hmpps-wiremock/Dockerfile
+++ b/hmpps-wiremock/Dockerfile
@@ -1,7 +1,16 @@
 FROM wiremock/wiremock:3.9.1
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get autoremove -y && \
+    apt-get install -y git jq &&  \
+    rm -rf /var/lib/apt/lists/*
+
 RUN addgroup --gid 2000 --system wiremock && adduser --uid 2000 --system wiremock --gid 2000
 
 COPY --chown=wiremock:wiremock wiremock /home/wiremock
+COPY --chmod=0755 entrypoint.sh /entrypoint.sh
 
 USER 2000
-ENTRYPOINT ["/docker-entrypoint.sh", "--port=8090", "--global-response-templating", "--disable-gzip", "--verbose"]
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/hmpps-wiremock/README.md
+++ b/hmpps-wiremock/README.md
@@ -1,0 +1,41 @@
+# HMPPS WireMock
+
+`hmpps-wiremock` is a Docker container designed to deploy a WireMock server with mappings and 
+response files.
+
+## Features
+
+- **Pull and deploy WireMock mappings from a list of repositories** specified via environment variables.
+    - **Extracts WireMock mappings** from each repository.
+    - **Removes duplicate stub IDs** to prevent conflicts.
+- **Use built-in WireMocks, stored in `wiremock/`**
+- **Starts a WireMock server** on port `8090`.
+
+---
+
+## Usage
+
+### **Environment Variables**
+The container uses the following environment variables:
+
+| Variable           | Description                                                        |
+|-------------------|--------------------------------------------------------------------|
+| `WIREMOCK_REPOS`  | JSON array of repositories to clone (see example below).           |
+| `GITHUB_TOKEN`    | Personal Access Token (PAT) used for cloning private repositories. |
+
+### **Example `WIREMOCK_REPOS` Configuration**
+You can pass `WIREMOCK_REPOS` as a JSON array of repositories, branches, and paths.
+
+```json
+[
+  {
+    "repoUrl": "https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui",
+    "branch": "main",
+    "path": "wiremock"
+  },
+  {
+    "repoUrl": "https://github.com/ministryofjustice/hmpps-approved-premises-api",
+    "branch": "main",
+    "path": "wiremock"
+  }
+]

--- a/hmpps-wiremock/entrypoint.sh
+++ b/hmpps-wiremock/entrypoint.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -e
+
+WIREMOCK_MAPPINGS_DIR="/home/wiremock/mappings"
+mkdir -p "${WIREMOCK_MAPPINGS_DIR}"
+
+WIREMOCK_FILES_DIR="/home/wiremock/__files"
+mkdir -p "${WIREMOCK_FILES_DIR}"
+
+clone_and_copy() {
+    local repoSpec="$1"
+    local repoUrl=$(echo "${repoSpec}" | jq -r '.repoUrl')
+    local branch=$(echo "${repoSpec}" | jq -r '.branch')
+    local mappingsPath=$(echo "${repoSpec}" | jq -r '.path')
+    local repoUrlNoGit=$(echo "${repoUrl}" | sed 's/\.git$//')
+    local repoName=$(basename "${repoUrlNoGit}")
+
+    echo ""
+    echo "Repo: ${repoName}"
+    echo "   Cloning ${repoUrl} (branch: ${branch})..."
+
+    cloneDir="/tmp/wiremock-${repoName}@${branch}"
+
+    if [[ -n "${GITHUB_TOKEN}" ]]; then
+      repoUrl=$(echo "$repoUrl" | sed "s|https://github.com/|https://$GITHUB_TOKEN@github.com/|")
+    fi
+    git clone --quiet --depth=1 --branch "${branch}" "${repoUrl}" "${cloneDir}"
+
+    targetDir="${cloneDir}/${mappingsPath}"
+    if [ ! -d "${targetDir}" ]; then
+        echo "   Error: The specified path '${mappingsPath}' does not exist in the repository."
+        exit 1
+    fi
+
+    if [ -d "${targetDir}/mappings" ]; then
+        echo "   Copying mappings from '${targetDir}/mappings' to '${WIREMOCK_MAPPINGS_DIR}'..."
+        cp -r "${targetDir}/mappings/." "${WIREMOCK_MAPPINGS_DIR}"
+    else
+        echo "   Warning: No 'mappings' directory found at '${targetDir}'."
+    fi
+
+    if [ -d "${targetDir}/__files" ]; then
+        echo "   Copying __files from '${targetDir}/__files' to '${WIREMOCK_FILES_DIR}'..."
+        cp -r "${targetDir}/__files/." "${WIREMOCK_FILES_DIR}"
+    else
+        echo "   Warning: No '__files' directory found at '${targetDir}'."
+    fi
+
+    rm -rf "${cloneDir}"
+
+    echo "   Finished processing '${repoUrl}'"
+    echo ""
+}
+
+if [[ -n "${WIREMOCK_REPOS}" ]]; then
+    echo "Parsing repos from WIREMOCK_REPOS"
+    echo "${WIREMOCK_REPOS}" | jq -c '.[]' | while read -r repoSpec; do
+        clone_and_copy "${repoSpec}"
+    done
+else
+    echo "No WIREMOCK_REPOS provided—using existing mappings in ${WIREMOCK_MAPPINGS_DIR}."
+fi
+
+echo "Checking for duplicate WireMock stub 'id' fields..."
+declare -A seenIds
+
+while IFS= read -r -d '' stubFile; do
+    currentId="$(jq -r '.id // empty' "${stubFile}" 2>/dev/null || true)"
+    if [ -n "${currentId}" ]; then
+        if [[ -v "seenIds[${currentId}]" ]]; then
+            echo "   Removing file ${stubFile} because wiremock ID '${currentId}' is already present."
+            rm -f "${stubFile}"
+        else
+            seenIds["${currentId}"]=1
+        fi
+    fi
+done < <(find "${WIREMOCK_MAPPINGS_DIR}" -type f -name "*.json" -print0)
+
+echo "Starting WireMock..."
+exec /docker-entrypoint.sh --port=8090 --global-response-templating --disable-gzip --verbose


### PR DESCRIPTION
> **Note:** I understand that the intention for this container is probably for teams to upload their WireMocks into this repository by default; but seemingly that isn't happening so this is the next best thing

- Add support for hmpps-wiremock to pull Wiremock mappings from other GitHub repositories
- Remove any duplicate stubs
- Still serve default stubs (to not make this breaking)
- Added README
