### PR TITLE
Add hmpps-jdk-debug image for Kubernetes ephemeral container debugging

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         dockerfile-dir:
           - hmpps-devops-tools
+          - hmpps-jdk-debug
           - hmpps-mssql-tools
           - hmpps-mysql-tools
           - hmpps-postgres-tools

--- a/hmpps-jdk-debug/Dockerfile
+++ b/hmpps-jdk-debug/Dockerfile
@@ -1,0 +1,16 @@
+FROM eclipse-temurin:25-jdk-jammy
+
+RUN apt-get clean && apt-get update && apt-get upgrade -y \
+    && apt-get install --no-install-recommends -qy locales tzdata curl jq procps \
+    && locale-gen en_GB.UTF-8 \
+    && ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
+    && dpkg-reconfigure -f noninteractive tzdata \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /.cache/*
+
+RUN addgroup --gid 2000 --system appgroup && \
+    adduser --uid 2000 --system appuser --gid 2000 --home /home/appuser
+
+USER 2000
+
+CMD ["/bin/bash"]

--- a/hmpps-jdk-debug/README.md
+++ b/hmpps-jdk-debug/README.md
@@ -1,0 +1,37 @@
+# HMPPS JDK Debug Image
+
+A JDK image based on Eclipse Temurin 25 for use as a Kubernetes ephemeral container to debug running Java applications.
+
+## Features
+
+- **Eclipse Temurin 25 JDK** - Full JDK with diagnostic tools (jcmd, jstack, jmap, jfr, etc.)
+- **Runs as UID 2000** - Matches standard HMPPS application containers
+
+## Usage
+
+### As an Ephemeral Container
+
+```bash
+kubectl debug -it <pod-name> --image=ghcr.io/ministryofjustice/hmpps-jdk-debug:latest --target=<container-name>
+```
+
+### Common Debugging Commands
+
+```bash
+# List Java processes
+jps -l
+
+# Thread dump
+jstack <pid>
+
+# Heap dump
+jmap -dump:format=b,file=/tmp/heap.hprof <pid>
+
+# JVM diagnostics
+jcmd <pid> VM.info
+jcmd <pid> GC.heap_info
+jcmd <pid> Thread.print
+
+# Start a flight recording
+jcmd <pid> JFR.start duration=60s filename=/tmp/recording.jfr
+```


### PR DESCRIPTION
Eclipse Temurin 25 JDK image with diagnostic tools (jcmd, jstack, jmap, jfr)
for debugging running Java applications via kubectl debug.
