### PR TITLE
MAPB-405 update localstack version to community-archive

### DIFF
--- a/hmpps-localstack/Dockerfile
+++ b/hmpps-localstack/Dockerfile
@@ -1,4 +1,4 @@
-FROM localstack/localstack:stable
+FROM localstack/localstack:community-archive
 RUN chown localstack:localstack -R /tmp/localstack && \
     chown localstack:localstack -R /var/lib/localstack
 USER 1000


### PR DESCRIPTION
Update to use the community-archive. We are getting an auth failure now after the latest localstack requirement for authentication. Realised when using our locations training environment. The community one still works.

```
kubectl -n hmpps-locations-****logs --follow hmpps-locations-**** -c localstack

LocalStack version: 2026.4.0
LocalStack build date: 2026-04-29
LocalStack build git hash: 468381841

Localstack returning with exit code 55. Reason: 
===============================================
License activation failed! 🔑❌

Reason: No credentials were found in the environment. Please make sure to either set the LOCALSTACK_AUTH_TOKEN variable to a valid auth token. If you are using the CLI, you can also run `localstack auth set-token`.

Due to this error, Localstack has quit. LocalStack pro features can only be used with a valid license.

- Please check that your credentials are set up correctly and that you have an active license.
  You can find your credentials in our webapp at https://app.localstack.cloud/.kubectl -n hmpps-locations-*** logs --follow hmpps-locations-***** -c localstack

LocalStack version: 2026.4.0
LocalStack build date: 2026-04-29
LocalStack build git hash: 468381841

Localstack returning with exit code 55. Reason: 
===============================================
License activation failed! 🔑❌

Reason: No credentials were found in the environment. Please make sure to either set the LOCALSTACK_AUTH_TOKEN variable to a valid auth token. If you are using the CLI, you can also run `localstack auth set-token`.

Due to this error, Localstack has quit. LocalStack pro features can only be used with a valid license.

- Please check that your credentials are set up correctly and that you have an active license.
  You can find your credentials in our webapp at https://app.localstack.cloud/.
```

